### PR TITLE
Implement argparse functionality, fix bearing bug

### DIFF
--- a/cellspacer.py
+++ b/cellspacer.py
@@ -86,6 +86,7 @@ def main():
                 if value == flagonsolo:
                     latlongspaced = latlong
                     areacount = 1
+                    bearing = "N/A"
                 else:
                     areacount = masterdict[latlong][0]
                     bearing = (value * 360 / areacount)

--- a/cellspacer.py
+++ b/cellspacer.py
@@ -10,6 +10,7 @@ This may use a lot of memory on large datasets, so you might want it to work off
 """
 
 from __future__ import print_function
+import argparse
 import csv
 import sys
 
@@ -40,68 +41,70 @@ def get_spot(latlong, value):
 
 
 def main():
-    try:
-        inputfilename = sys.argv[1]
-        outputfilename = inputfilename[:inputfilename.rfind(".")] + "-jitter" +inputfilename[inputfilename.rfind("."):]
-        with open(inputfilename, 'r') as inputfilehandle:
-            rows = csv.reader(inputfilehandle)
-            headers = next(rows)
-            for row in rows:
-                latlong = row[-1]
+    inputfilename = args.filename
+    outputfilename = inputfilename[:inputfilename.rfind(".")] + "-jitter" + inputfilename[inputfilename.rfind("."):]
+    with open(inputfilename, 'r') as inputfilehandle:
+        rows = csv.reader(inputfilehandle)
+        headers = next(rows)
+        for row in rows:
+            latlong = row[-1]
         # We're only grabbing latlong from last field
-                set_spot(latlong)
+            set_spot(latlong)
         # masterdict should now have all latlongs, and their counts
         # and inputfilehandle should now be closed.
         # Let's now set up our spot dictionary:
 
-        for key in masterdict:
-            if masterdict[key][0] == 1:
-                masterdict[key][1] = flagonsolo
-            else:
-                masterdict[key][1] = 0
+    for key in masterdict:
+        if masterdict[key][0] == 1:
+            masterdict[key][1] = flagonsolo
+        else:
+            masterdict[key][1] = 0
 ## We should be ready to start processing. Our masterdict holds a list keyed to each unique latlong in our
 ## source CSV. [0] holds how many values are at that index. [1] holds an index to which one of those things
 ## we're processing, so we know where to jigger it.
 ## flagonsolo gives us a value that says, "Only one point at this latlong. Don't mess with it."
 
-        with open(outputfilename, 'w') as outputfile:
-            put = csv.writer(outputfile)
-            with open(inputfilename, 'r') as inputfilehandle:
-                rows = csv.reader(inputfilehandle)
-                headers = next(rows)
-                headers.append("RowsHere")
-                headers.append("latlongspaced")
-                put.writerow(headers)
-                for row in rows:
-                    latlong = row[-1]
-                    value = -700
-#					get_spot(latlong, value)
-                    Bud, Schlitz = get_spot(latlong, value)
-#					print "Tequila" + str(value)
-#					print "Schlitz " + str(Schlitz)
-                    value = Schlitz
-                    if value == flagonsolo:
-                        latlongspaced = latlong
-                        areacount = 1
-                    else:
-                        areacount = masterdict[latlong][0]
-                        bearing = value*360 / areacount
-                        destination = VincentyDistance(meters=100).destination(latlong, bearing)
-                        latlongspaced = str(destination.latitude) + ", " + str(destination.longitude)
-                    if verbose == 1:
-                        print("Latlong:" + "\t" + latlong + "\t" + "Area count:" + "\t" + str(areacount) + "\t" + "Index count:" + "\t" + str(value) + "\t" + "Spaced:" + "\t" + latlongspaced + "\t" + "Bearing" + "\t" + str(bearing))
-                    row.append(str(areacount))
-                    row.append(latlongspaced)
-                    put.writerow(row)
-        if verbose == 1:
-            linecount = 0
-            for key in masterdict:
-                linecount = linecount + masterdict[key][0]
-            print("Processed " + str(linecount) + " rows at " + str(len(masterdict)) + " locations.")
-    except IndexError:
-        print('Run this script with the CSV filename you want to scatter, like "cellspacer.py mydata.csv"')
-        print('The final column must contain the geocoded field, e.g, "-80.213, 40.4742")')
+    with open(outputfilename, 'w') as outputfile:
+        put = csv.writer(outputfile)
+        with open(inputfilename, 'r') as inputfilehandle:
+            rows = csv.reader(inputfilehandle)
+            headers = next(rows)
+            headers.append("RowsHere")
+            headers.append("latlongspaced")
+            put.writerow(headers)
+            for row in rows:
+                latlong = row[-1]
+                value = -700
+#				get_spot(latlong, value)
+                Bud, Schlitz = get_spot(latlong, value)
+#				print "Tequila" + str(value)
+#				print "Schlitz " + str(Schlitz)
+                value = Schlitz
+                if value == flagonsolo:
+                    latlongspaced = latlong
+                    areacount = 1
+                else:
+                    areacount = masterdict[latlong][0]
+                    bearing = value*360 / areacount
+                    destination = VincentyDistance(meters=100).destination(latlong, bearing)
+                    latlongspaced = str(destination.latitude) + ", " + str(destination.longitude)
+                if verbose == 1:
+                    print("Latlong:" + "\t" + latlong + "\t" + "Area count:" + "\t" + str(areacount) + "\t" + "Index count:" + "\t" + str(value) + "\t" + "Spaced:" + "\t" + latlongspaced + "\t" + "Bearing" + "\t" + str(bearing))
+                row.append(str(areacount))
+                row.append(latlongspaced)
+                put.writerow(row)
+    if verbose == 1:
+        linecount = 0
+        for key in masterdict:
+            linecount = linecount + masterdict[key][0]
+        print("Processed " + str(linecount) + " rows at " + str(len(masterdict)) + " locations.")
 
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser(description="Lat-longs to scatter")
+    parser.add_argument('filename', metavar='filename', help='CSV file containing Lat-longs to scatter')
+    args = parser.parse_args()
+    if args.filename.lower().endswith('.csv'):
+        main()
+    else:
+        print("File must be of type CSV and end with .csv extension")

--- a/cellspacer.py
+++ b/cellspacer.py
@@ -18,8 +18,8 @@ from geopy.distance import VincentyDistance
 
 masterdict = {}
 flagonsolo = 987654321
-verbose = 0
-verbose = 1				## Comment this line out if you don't want feedback.
+verbose = 1
+# verbose = 1				## Comment this line out if you don't want feedback.
 
 
 def set_spot(latlong):
@@ -27,6 +27,7 @@ def set_spot(latlong):
         masterdict[latlong][0] += 1
     else:
         masterdict[latlong] = [1,-1]
+
 # So if we have a value, we know this spot already and we should add to the count.
 # If we don't have a value, we need to create one, set to the 1.
 
@@ -59,6 +60,7 @@ def main():
             masterdict[key][1] = flagonsolo
         else:
             masterdict[key][1] = 0
+
 ## We should be ready to start processing. Our masterdict holds a list keyed to each unique latlong in our
 ## source CSV. [0] holds how many values are at that index. [1] holds an index to which one of those things
 ## we're processing, so we know where to jigger it.
@@ -77,6 +79,7 @@ def main():
                 value = -700
 #				get_spot(latlong, value)
                 Bud, Schlitz = get_spot(latlong, value)
+
 #				print "Tequila" + str(value)
 #				print "Schlitz " + str(Schlitz)
                 value = Schlitz
@@ -85,11 +88,11 @@ def main():
                     areacount = 1
                 else:
                     areacount = masterdict[latlong][0]
-                    bearing = value*360 / areacount
+                    bearing = (value * 360 / areacount)
                     destination = VincentyDistance(meters=100).destination(latlong, bearing)
                     latlongspaced = str(destination.latitude) + ", " + str(destination.longitude)
                 if verbose == 1:
-                    print("Latlong:" + "\t" + latlong + "\t" + "Area count:" + "\t" + str(areacount) + "\t" + "Index count:" + "\t" + str(value) + "\t" + "Spaced:" + "\t" + latlongspaced + "\t" + "Bearing" + "\t" + str(bearing))
+                    print("Latlong:" + "\t" + latlong + "\t" + "Area count:" + "\t" + str(areacount) + "\t" + "Index count:" + "\t" + str(value) + "\t" + "Spaced:" + "\t" + latlongspaced + "\t" + "Bearing " + "\t" + str(bearing))
                 row.append(str(areacount))
                 row.append(latlongspaced)
                 put.writerow(row)

--- a/cellspacer.py
+++ b/cellspacer.py
@@ -18,7 +18,7 @@ from geopy.distance import VincentyDistance
 
 masterdict = {}
 flagonsolo = 987654321
-verbose = 1
+
 # verbose = 1				## Comment this line out if you don't want feedback.
 
 
@@ -41,7 +41,7 @@ def get_spot(latlong, value):
 # Let's peel the latest index count off, and increment by 1, unless this is the only spot at the location.
 
 
-def main():
+def main(verbose=0):
     inputfilename = args.filename
     outputfilename = inputfilename[:inputfilename.rfind(".")] + "-jitter" + inputfilename[inputfilename.rfind("."):]
     with open(inputfilename, 'r') as inputfilehandle:
@@ -107,8 +107,12 @@ def main():
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Lat-longs to scatter")
     parser.add_argument('filename', metavar='filename', help='CSV file containing Lat-longs to scatter')
+    parser.add_argument("-v", help="turn on verbose output", action="store_true")
     args = parser.parse_args()
     if args.filename.lower().endswith('.csv'):
-        main()
+        if args.v:
+            main(verbose=1)
+        else:
+            main()
     else:
         print("File must be of type CSV and end with .csv extension")

--- a/postgeo.py
+++ b/postgeo.py
@@ -29,7 +29,7 @@ lastlatlong = "-77.036482, 38.897667"
 
 try:
     inputfilename = sys.argv[1]
-    outputfilename = inputfilename[:inputfilename.rfind(".")] + "-geo" +inputfilename[inputfilename.rfind("."):]
+    outputfilename = inputfilename[:inputfilename.rfind(".")] + "-geo" + inputfilename[inputfilename.rfind("."):]
     with open(outputfilename, 'w') as outputfile:
         put = csv.writer(outputfile)
         with open(inputfilename, 'r') as inputfilehandle:

--- a/postgeo.py
+++ b/postgeo.py
@@ -5,6 +5,7 @@ Your full address field -- "1600 Pennsylvania Ave. NW, Washington, D.C., USA" --
 """
 
 from __future__ import print_function
+import argparse
 import sys
 import csv
 import time
@@ -17,18 +18,17 @@ GoogleAPIkey = creds.access['GoogleAPIkey']
 
 geolocator = GoogleV3(api_key=GoogleAPIkey, timeout=10)
 
-
-
-
 # Let's set up a buffer, in case we're running with a sorted list that has overlapping points.
-lastfulladdy = "1600 Pennsylvania Ave. NW, Washington, D.C. 20500"
-lastlat = "-77.036482"
-lastlong = "38.897667"
-lastaccuracy = "Rooftop"
-lastlatlong = "-77.036482, 38.897667"
 
-try:
-    inputfilename = sys.argv[1]
+
+def main():
+    lastfulladdy = "1600 Pennsylvania Ave. NW, Washington, D.C. 20500"
+    lastlat = "-77.036482"
+    lastlong = "38.897667"
+    lastaccuracy = "Rooftop"
+    lastlatlong = "-77.036482, 38.897667"
+    inputfilename = args.filename
+
     outputfilename = inputfilename[:inputfilename.rfind(".")] + "-geo" + inputfilename[inputfilename.rfind("."):]
     with open(outputfilename, 'w') as outputfile:
         put = csv.writer(outputfile)
@@ -71,6 +71,13 @@ try:
                         time.sleep(1)
                     except AttributeError:
                         print("Something went wrong on " + fulladdy)
-except IndexError:
-    print('Run this script with the CSV filename you want to geocode, like "postgeo.py mydata.csv"')
-    print('Geocodable location data must be in the last field.')
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Address file to geocode")
+    parser.add_argument('filename', metavar='filename', help='CSV file containing addresses to be geocoded')
+    args = parser.parse_args()
+    if args.filename.lower().endswith('.csv'):
+        print(args.filename)
+        main()
+    else:
+        print("File must be of type CSV and end with .csv extension")


### PR DESCRIPTION
Added argparse functionality which allows for better checking for cvs file and adds usage message for users. Also added an optional verbosity argument to cellspacer.py to make it easier for the user to specify verbosity. The default is now non-verbose and the user can merely add -v argument to turn it on. For example,

`python3 cellspacer.py coordinates.csv -v` 

will turn on verbose and print results to stdout as before.
