### PR TITLE
Show --help message anytime there is an argument error

### DIFF
--- a/cellspacer.py
+++ b/cellspacer.py
@@ -16,7 +16,6 @@ import argparse
 import csv
 import os
 import sys
-import traceback
 
 from geopy.distance import VincentyDistance
 

--- a/cellspacer.py
+++ b/cellspacer.py
@@ -112,7 +112,6 @@ def main(spacing, verbose=0):
         print(processed_string.format(linecount, len(masterdict)))
 
 if __name__ == '__main__':
-    # TODO: add flag for meters for spacing.
     parser = argparse.ArgumentParser(description="Lat-longs to scatter")
     parser.add_argument('filename', metavar='filename', help='CSV file containing Lat-longs to scatter')
     parser.add_argument("-v", help="turn on verbose output", action="store_true")

--- a/cellspacer.py
+++ b/cellspacer.py
@@ -16,6 +16,7 @@ import argparse
 import csv
 import os
 import sys
+import traceback
 
 from geopy.distance import VincentyDistance
 
@@ -116,7 +117,12 @@ if __name__ == '__main__':
     parser.add_argument('filename', metavar='filename', help='CSV file containing Lat-longs to scatter')
     parser.add_argument("-v", help="turn on verbose output", action="store_true")
     parser.add_argument("-m", help="set distance in meters for spacing", default=100, type=int)
-    args = parser.parse_args()
+
+    try:
+        args = parser.parse_args()
+    except:
+        parser.print_help()
+        sys.exit(1)
     get_input = input
     if sys.version_info[:2] <= (2, 7):
         get_input = raw_input

--- a/postgeo.py
+++ b/postgeo.py
@@ -5,10 +5,11 @@ Your full address field -- "1600 Pennsylvania Ave. NW, Washington, D.C., USA" --
 """
 
 from __future__ import print_function
+
 import argparse
-import sys
 import csv
 import os
+import sys
 import time
 
 from geopy.geocoders import GoogleV3
@@ -41,9 +42,10 @@ def main():
             print('Aborting . . .')
             exit()
 
-    with open(outputfilename, 'w') as outputfile:
-        put = csv.writer(outputfile, lineterminator='\n')
-        with open(inputfilename, 'r') as inputfilehandle:
+    with open(outputfilename, 'wb') as outputfile:
+#       put = csv.writer(outputfile, lineterminator='\n')
+        put = csv.writer(outputfile)
+        with open(inputfilename, 'rU') as inputfilehandle:
             rows = csv.reader(inputfilehandle)
             headers = next(rows)
             headers.append("lat")
@@ -87,7 +89,13 @@ def main():
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Address file to geocode")
     parser.add_argument('filename', metavar='filename', help='CSV file containing addresses to be geocoded')
-    args = parser.parse_args()
+
+    try:
+        args = parser.parse_args()
+    except:
+        parser.print_help()
+        sys.exit(1)
+
     get_input = input
 
     if sys.version_info[:2] <= (2, 7):

--- a/postgeo.py
+++ b/postgeo.py
@@ -93,7 +93,11 @@ def main():
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Address file to geocode")
     parser.add_argument('filename', metavar='filename', help='CSV file containing addresses to be geocoded')
-    args = parser.parse_args()
+    try:
+        args = parser.parse_args()
+    except:
+        parser.print_help()
+        sys.exit(1)
     get_input = input
 
     if sys.version_info[:2] <= (2, 7):


### PR DESCRIPTION
Attempting to run either script without specifying an input file name or using an invalid argument will generate the full argparse -h message.
